### PR TITLE
Changes to QIIME 1.5.0-dev config

### DIFF
--- a/qiime-1.5.0-dev/qiime.conf
+++ b/qiime-1.5.0-dev/qiime.conf
@@ -74,25 +74,20 @@ release-location: http://sourceforge.net/projects/sqlalchemy/files/sqlalchemy/0.
 deps: python
 
 [pycogent]
-version: 1.5.1
+version: 1.5.2
 build-type: python-distutils
-repository-local-name: PyCogent
-repository-location: https://pycogent.svn.sourceforge.net/svnroot/pycogent/trunk
-repository-type: svn
-repository-options: --trust-server-cert --non-interactive
-copy-source-to-final-deploy: yes
-deps: numpy
+release-file-name: PyCogent-1.5.2.tgz
 set-environment-variables-value: TEST_DB=1
+copy-source-to-final-deploy: yes
+release-location: http://downloads.sourceforge.net/project/pycogent/PyCogent/1.5.2/PyCogent-1.5.2.tgz
+deps: numpy
 set-environment-variables-deploypath: PYCOGENT=./
 
 [pynast]
 version: 1.1
 build-type: python-distutils
-repository-local-name: PyNAST
-repository-location: https://pynast.svn.sourceforge.net/svnroot/pynast
-repository-type: svn
-repository-options: --trust-server-cert --non-interactive
-copy-source-to-final-deploy: yes
+release-file-name: PyNAST-1.1.tgz
+release-location: http://downloads.sourceforge.net/project/pynast/PyNAST%20releases/PyNAST-1.1.tgz
 relative-directory-add-to-path: bin
 deps: pycogent
 
@@ -261,23 +256,19 @@ relative-directory-add-to-path: .
 [pprospector]
 version: 1.0.1
 build-type: python-distutils
-repository-local-name: pprospector
-repository-location: https://pprospector.svn.sourceforge.net/svnroot/pprospector/trunk
-repository-type: svn
-repository-options: --trust-server-cert --non-interactive
-copy-source-to-final-deploy: yes
+release-file-name: pprospector-1.0.1.tar.gz
+release-location: http://sourceforge.net/projects/pprospector/files/pprospector-1.0.1.tar.gz
 relative-directory-add-to-path: bin
 deps: pycogent
 
 [biom-format]
 version: 1.0.0
 build-type: copy
-repository-local-name: biom-format
-repository-location: git://github.com/biom-format/biom-format.git
-repository-type: git
-deps: python, numpy
+release-file-name: biom-format-1.0.0.tgz
+release-location: https://github.com/downloads/biom-format/biom-format/biom-format-1.0.0.tgz
 set-environment-variables-deploypath: PYTHONPATH=python-code/
 relative-directory-add-to-path: scripts/
+deps: python, numpy
 
 [rtax]
 version: 0.982


### PR DESCRIPTION
Changed PyCogent from dev to 1.5.2, PyNAST from dev to 1.1, PrimerProspector from dev to 1.0.1, and biom-format from dev to 1.0.0 to keep QIIME 1.5.0-dev consistent with its required dependencies (and to upgrade to the newest version of PyCogent).

It was determined that running QIIME with the dev versions of the packages listed above could cause problems (e.g. if someone wrote QIIME code that relied on code that only existed in the dev version of a package).
