### PR TITLE
Added BLAT and BWA to QIIME 1.5.0-dev conf.

### DIFF
--- a/qiime-1.5.0-dev/qiime.conf
+++ b/qiime-1.5.0-dev/qiime.conf
@@ -332,3 +332,19 @@ build-type: python-distutils
 release-file-name: setuptools-0.6c11.tar.gz
 release-location: http://pypi.python.org/packages/source/s/setuptools/setuptools-0.6c11.tar.gz
 deps: python
+
+[bwa]
+version: 0.6.2
+build-type: make
+release-file-name: bwa-0.6.2.tar.bz2
+unzipped-name: bwa-0.6.2
+release-location: http://downloads.sourceforge.net/project/bio-bwa/bwa-0.6.2.tar.bz2
+relative-directory-add-to-path: .
+
+[blat]
+version: 34
+build-type: copy
+release-file-name: blatSuite.34.zip
+release-location: http://hgwdev.cse.ucsc.edu/~kent/exe/linux/blatSuite.34.zip
+relative-directory-add-to-path: .
+skip-unzipped-name: yes


### PR DESCRIPTION
These are new app controllers in PyCogent 1.5.2 that are now used in QIIME. This change is also needed so that the automated testing system can start testing them.

This conf file was tested on an Ubuntu EC2 instance.
