### PR TITLE
Adding env variables to ignore atlas/blas/lapack while installing python

### DIFF
--- a/qiime-1.5.0-dev/qiime.conf
+++ b/qiime-1.5.0-dev/qiime.conf
@@ -47,6 +47,7 @@ repository-type: git
 version: 2.7.1
 build-type: autoconf
 release-file-name: Python-2.7.1.tgz
+set-environment-variables-value: ATLAS=None,BLAS=None,LAPACK=None
 release-location: ftp://thebeast.colorado.edu/pub/QIIME-v1.5.0-dependencies/Python-2.7.1.tgz
 relative-directory-add-to-path: bin
 #autoconf-make-options: -j4


### PR DESCRIPTION
This modification is due to the illegal exception error we have seen in EC2 when running in certain instances. When we looked at this problem we saw that the error didn't happen when we only installed numpy vs. numpy+atlas.
