### PR TITLE
sourcetracker fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# vi .swp files
+.*.swp

--- a/qiime-1.5.0-dev/qiime.conf
+++ b/qiime-1.5.0-dev/qiime.conf
@@ -365,6 +365,7 @@ skip-unzipped-name: yes
 [sourcetracker]
 version: 0.9.4
 build-type: copy
+release-file-name: sourcetracker-0.9.4.tar.gz
 release-location: http://sourceforge.net/projects/sourcetracker/files/sourcetracker-0.9.4.tar.gz
 relative-directory-add-to-path: .
 set-environment-variables-deploypath: SOURCETRACKER_PATH=src/SourceTracker.r


### PR DESCRIPTION
Fixed issue with sourcetracker target that causes deploy to hang. Modified `.gitignore` to ignore vi .swp files.
