### PR TITLE
Fix to biom-format 1.1.0-dev conf

### DIFF
--- a/biom-format-1.1.0-dev/biom-format.conf
+++ b/biom-format-1.1.0-dev/biom-format.conf
@@ -45,6 +45,7 @@ repository-local-name: biom-format
 repository-location: git://github.com/biom-format/biom-format.git
 repository-type: git
 relative-directory-add-to-path: bin
+copy-source-to-final-deploy: yes
 deps: python, cython, numpy
 
 [cython]


### PR DESCRIPTION
Source is now left in place so that we can run the tests in Clout.
