### PR TITLE
Fixed python targets for 2.7.3.

### DIFF
--- a/biom-format-1.1.1-dev/biom-format.conf
+++ b/biom-format-1.1.1-dev/biom-format.conf
@@ -23,13 +23,15 @@ append-environment-to-bashrc: yes
 append-environment-to-bashprofile: no
 
 [python]
-version: 2.7.1
+version: 2.7.3
 build-type: autoconf
-release-file-name: Python-2.7.1.tgz
-release-location: ftp://thebeast.colorado.edu/pub/QIIME-v1.5.0-dependencies/Python-2.7.1.tgz
+release-file-name: Python-2.7.3.tgz
+set-environment-variables-value: ATLAS=None,BLAS=None,LAPACK=None
+release-location: http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
 relative-directory-add-to-path: bin
 #autoconf-make-options: -j4
-autoconf-configure-options: --enable-shared --with-zlib=/usr/include --enable-unicode=ucs2 --enable-unicode=ucs4
+autoconf-configure-options: --enable-shared --enable-unicode=ucs2 --enable-unicode=ucs4
+set-environment-variables-deploypath: LD_LIBRARY_PATH=lib
 
 [numpy]
 version: 1.5.1

--- a/primer-prospector-1.0.1-dev/primer-prospector.conf
+++ b/primer-prospector-1.0.1-dev/primer-prospector.conf
@@ -23,13 +23,15 @@ append-environment-to-bashrc: yes
 append-environment-to-bashprofile: no
 
 [python]
-version: 2.7.1
+version: 2.7.3
 build-type: autoconf
-release-file-name: Python-2.7.1.tgz
-release-location: ftp://thebeast.colorado.edu/pub/QIIME-v1.5.0-dependencies/Python-2.7.1.tgz
+release-file-name: Python-2.7.3.tgz
+set-environment-variables-value: ATLAS=None,BLAS=None,LAPACK=None
+release-location: http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
 relative-directory-add-to-path: bin
 #autoconf-make-options: -j4
-autoconf-configure-options: --enable-shared --with-zlib=/usr/include --enable-unicode=ucs2 --enable-unicode=ucs4
+autoconf-configure-options: --enable-shared --enable-unicode=ucs2 --enable-unicode=ucs4
+set-environment-variables-deploypath: LD_LIBRARY_PATH=lib
 
 [pycogent]
 version: 1.5.3

--- a/pycogent-1.5.3-dev/pycogent.conf
+++ b/pycogent-1.5.3-dev/pycogent.conf
@@ -23,12 +23,15 @@ append-environment-to-bashrc: yes
 append-environment-to-bashprofile: no
 
 [python]
-version: 2.7.1
+version: 2.7.3
 build-type: autoconf
-release-file-name: Python-2.7.1.tgz
-release-location: ftp://thebeast.colorado.edu/pub/QIIME-v1.5.0-dependencies/Python-2.7.1.tgz
+release-file-name: Python-2.7.3.tgz
+set-environment-variables-value: ATLAS=None,BLAS=None,LAPACK=None
+release-location: http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
 relative-directory-add-to-path: bin
-autoconf-configure-options: --enable-shared --with-zlib=/usr/include --enable-unicode=ucs2 --enable-unicode=ucs4
+#autoconf-make-options: -j4
+autoconf-configure-options: --enable-shared --enable-unicode=ucs2 --enable-unicode=ucs4
+set-environment-variables-deploypath: LD_LIBRARY_PATH=lib
 
 [MySQL-python]
 version: 1.2.3

--- a/pynast-1.2-dev/pynast.conf
+++ b/pynast-1.2-dev/pynast.conf
@@ -23,13 +23,15 @@ append-environment-to-bashrc: yes
 append-environment-to-bashprofile: no
 
 [python]
-version: 2.7.1
+version: 2.7.3
 build-type: autoconf
-release-file-name: Python-2.7.1.tgz
-release-location: ftp://thebeast.colorado.edu/pub/QIIME-v1.5.0-dependencies/Python-2.7.1.tgz
+release-file-name: Python-2.7.3.tgz
+set-environment-variables-value: ATLAS=None,BLAS=None,LAPACK=None
+release-location: http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
 relative-directory-add-to-path: bin
 #autoconf-make-options: -j4
-autoconf-configure-options: --enable-shared --with-zlib=/usr/include --enable-unicode=ucs2 --enable-unicode=ucs4
+autoconf-configure-options: --enable-shared --enable-unicode=ucs2 --enable-unicode=ucs4
+set-environment-variables-deploypath: LD_LIBRARY_PATH=lib
 
 [pycogent]
 version: 1.5.3

--- a/qiime-1.5.0-dev/qiime.conf
+++ b/qiime-1.5.0-dev/qiime.conf
@@ -51,7 +51,8 @@ set-environment-variables-value: ATLAS=None,BLAS=None,LAPACK=None
 release-location: http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
 relative-directory-add-to-path: bin
 #autoconf-make-options: -j4
-autoconf-configure-options: --enable-shared --with-zlib=/usr/include --enable-unicode=ucs2 --enable-unicode=ucs4
+autoconf-configure-options: --enable-shared --enable-unicode=ucs2 --enable-unicode=ucs4
+set-environment-variables-deploypath: LD_LIBRARY_PATH=lib
 
 [cython]
 version: 0.17


### PR DESCRIPTION
Removed the `--with-zlib` configure option because it is unrecognized in 2.7.3, and python will find the `zlib` library as long as `build-essential` is installed (which we recommend in the docs).

We have to set `LD_LIBRARY_PATH` (see [this answer](http://stackoverflow.com/a/7880519) for details) because otherwise running our custom built python will load the incorrect libpython from the system (version 2.7.2+, which is incompatible with python 2.7.3).

I tested this pretty thoroughly on EC2 and it appears to work.
