### PR TITLE
Uncommented make -j4 flags.

### DIFF
--- a/biom-format-1.1.2-dev/biom-format.conf
+++ b/biom-format-1.1.2-dev/biom-format.conf
@@ -29,7 +29,7 @@ release-file-name: Python-2.7.3.tgz
 set-environment-variables-value: ATLAS=None,BLAS=None,LAPACK=None
 release-location: http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
 relative-directory-add-to-path: bin
-#autoconf-make-options: -j4
+autoconf-make-options: -j4
 autoconf-configure-options: --enable-shared --enable-unicode=ucs2 --enable-unicode=ucs4
 set-environment-variables-deploypath: LD_LIBRARY_PATH=lib
 

--- a/primer-prospector-1.0.1-dev/primer-prospector.conf
+++ b/primer-prospector-1.0.1-dev/primer-prospector.conf
@@ -29,7 +29,7 @@ release-file-name: Python-2.7.3.tgz
 set-environment-variables-value: ATLAS=None,BLAS=None,LAPACK=None
 release-location: http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
 relative-directory-add-to-path: bin
-#autoconf-make-options: -j4
+autoconf-make-options: -j4
 autoconf-configure-options: --enable-shared --enable-unicode=ucs2 --enable-unicode=ucs4
 set-environment-variables-deploypath: LD_LIBRARY_PATH=lib
 

--- a/pycogent-1.5.3-dev/pycogent.conf
+++ b/pycogent-1.5.3-dev/pycogent.conf
@@ -29,7 +29,7 @@ release-file-name: Python-2.7.3.tgz
 set-environment-variables-value: ATLAS=None,BLAS=None,LAPACK=None
 release-location: http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
 relative-directory-add-to-path: bin
-#autoconf-make-options: -j4
+autoconf-make-options: -j4
 autoconf-configure-options: --enable-shared --enable-unicode=ucs2 --enable-unicode=ucs4
 set-environment-variables-deploypath: LD_LIBRARY_PATH=lib
 

--- a/pynast-1.2-dev/pynast.conf
+++ b/pynast-1.2-dev/pynast.conf
@@ -29,7 +29,7 @@ release-file-name: Python-2.7.3.tgz
 set-environment-variables-value: ATLAS=None,BLAS=None,LAPACK=None
 release-location: http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
 relative-directory-add-to-path: bin
-#autoconf-make-options: -j4
+autoconf-make-options: -j4
 autoconf-configure-options: --enable-shared --enable-unicode=ucs2 --enable-unicode=ucs4
 set-environment-variables-deploypath: LD_LIBRARY_PATH=lib
 

--- a/qiime-1.6.0-dev/qiime.conf
+++ b/qiime-1.6.0-dev/qiime.conf
@@ -50,7 +50,7 @@ release-file-name: Python-2.7.3.tgz
 set-environment-variables-value: ATLAS=None,BLAS=None,LAPACK=None
 release-location: http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
 relative-directory-add-to-path: bin
-#autoconf-make-options: -j4
+autoconf-make-options: -j4
 autoconf-configure-options: --enable-shared --enable-unicode=ucs2 --enable-unicode=ucs4
 set-environment-variables-deploypath: LD_LIBRARY_PATH=lib
 


### PR DESCRIPTION
I think this is a reasonable default to have, as the R and Infernal targets are already using `-j4`. This will help speed up the nightly Clout tests.
