### PR TITLE
Reverted R version back to 2.12.0 for now.

### DIFF
--- a/picrust-0.9.0-dev/picrust.conf
+++ b/picrust-0.9.0-dev/picrust.conf
@@ -77,12 +77,11 @@ deps: numpy
 set-environment-variables-deploypath: PYCOGENT=./
 
 [r]
-version: 2.12.2
+version: 2.12.0
 build-type: autoconf
-release-file-name: R-2.12.2.tar.gz
-release-location: http://cran.cnr.berkeley.edu/src/base/R-2/R-2.12.2.tar.gz
+release-file-name: R-2.12.0.tar.gz
+release-location: http://cran.case.edu/src/base/R-2/R-2.12.0.tar.gz
 relative-directory-add-to-path: bin
-autoconf-configure-options: --with-x=no
 autoconf-make-options: -j4
 
 [ape]

--- a/qiime-1.6.0-dev/qiime.conf
+++ b/qiime-1.6.0-dev/qiime.conf
@@ -236,12 +236,11 @@ release-location: http://drive5.com/uclust/uclustq1.2.22_i86linux64
 relative-directory-add-to-path: .
 
 [r]
-version: 2.12.2
+version: 2.12.0
 build-type: autoconf
-release-file-name: R-2.12.2.tar.gz
-release-location: http://cran.cnr.berkeley.edu/src/base/R-2/R-2.12.2.tar.gz
+release-file-name: R-2.12.0.tar.gz
+release-location: http://cran.case.edu/src/base/R-2/R-2.12.0.tar.gz
 relative-directory-add-to-path: bin
-autoconf-configure-options: --with-x=no
 autoconf-make-options: -j4
 
 [random-forest]


### PR DESCRIPTION
PICRUSt and QIIME builds are often hanging indefinitely, and after discussing with @gregcaporaso, we decided to revert for now since we have a QIIME release on Monday. We can then look into the failures and upgrade the version after the release.

I'll do a bit more debugging on my end and post details in a separate issue.
