### PR TITLE
Add emperor configuration file 

### DIFF
--- a/emperor-0.9.2-dev/emperor.conf
+++ b/emperor-0.9.2-dev/emperor.conf
@@ -33,6 +33,13 @@ autoconf-make-options: -j4
 autoconf-configure-options: --enable-shared --enable-unicode=ucs2 --enable-unicode=ucs4
 set-environment-variables-deploypath: LD_LIBRARY_PATH=lib
 
+[setuptools]
+version: 0.6c11
+build-type: python-distutils
+release-file-name: setuptools-0.6c11.tar.gz
+release-location: http://pypi.python.org/packages/source/s/setuptools/setuptools-0.6c11.tar.gz
+deps: python
+
 [numpy]
 version: 1.7.1
 build-type: python-distutils
@@ -56,6 +63,6 @@ repository-location: git://github.com/qiime/emperor.git
 repository-type: git
 relative-directory-add-to-path: bin
 copy-source-to-final-deploy: yes
-deps: numpy, qcli
+deps: numpy, qcli, setuptools
 set-environment-variables-deploypath: PYTHONPATH=lib/
 python-install-options: --install-scripts=bin/ --install-purelib=lib/


### PR DESCRIPTION
This configuration file supports an installation of Emperor only. This
should be useful to deploy in the Jenkins-CI server.
