### PR TITLE
Update to use SeqPrep v1.1

### DIFF
--- a/qiime-dev/qiime.conf
+++ b/qiime-dev/qiime.conf
@@ -278,12 +278,12 @@ release-location: https://ea-utils.googlecode.com/files/ea-utils.1.1.2-537.tar.g
 relative-directory-add-to-path: .
 
 [SeqPrep]
-version: latest
+version: v1.1
 build-type: make
 # These CFLAGS are the same as what's in the makefile, minus -Werror, which was
 # making the build fail on any warnings.
 make-options: CFLAGS='-c -Wall -O0 -g'
-repository-local-name: SeqPrep
-repository-location: git://github.com/jstjohn/SeqPrep.git
+release-location: https://github.com/jstjohn/SeqPrep/archive/v1.1.tar.gz
+release-file-name: SeqPrep-v1.1.tar.gz
+unzipped-name: SeqPrep-1.1
 relative-directory-add-to-path: .
-repository-type: git


### PR DESCRIPTION
Instead of the latest development version (this doesn't compile on Ubuntu). See https://github.com/jstjohn/SeqPrep/issues/22